### PR TITLE
Reintegrate Community-Driven Test Suites

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "ballerina/tests/resources"]
+	path = ballerina/tests/resources
+	url = https://github.com/nipunayf/toml-test
+	branch = resources

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "toml"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Ballerina"]
 keywords = ["toml"]
 repository = "https://github.com/ballerina-platform/module-ballerina-toml"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -91,7 +91,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "toml"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "io"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.8.0"
+distribution-version = "2201.9.0-20240229-103900-a949e6d4"
 
 [[package]]
 org = "ballerina"
@@ -40,12 +40,38 @@ version = "0.0.0"
 
 [[package]]
 org = "ballerina"
+name = "lang.__internal"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.object"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.array"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.__internal"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.error"
 version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
+
+[[package]]
+org = "ballerina"
+name = "lang.object"
+version = "0.0.0"
+scope = "testOnly"
 
 [[package]]
 org = "ballerina"
@@ -71,6 +97,7 @@ version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.array"},
 	{org = "ballerina", name = "lang.error"}
 ]
 modules = [

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.9.0-20240229-103900-a949e6d4"
+distribution-version = "2201.8.0"
 
 [[package]]
 org = "ballerina"
@@ -40,38 +40,12 @@ version = "0.0.0"
 
 [[package]]
 org = "ballerina"
-name = "lang.__internal"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.object"}
-]
-
-[[package]]
-org = "ballerina"
-name = "lang.array"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.__internal"}
-]
-
-[[package]]
-org = "ballerina"
 name = "lang.error"
 version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
-
-[[package]]
-org = "ballerina"
-name = "lang.object"
-version = "0.0.0"
-scope = "testOnly"
 
 [[package]]
 org = "ballerina"
@@ -97,7 +71,6 @@ version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.array"},
 	{org = "ballerina", name = "lang.error"}
 ]
 modules = [

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -104,6 +104,30 @@ publishing {
     }
 }
 
+task cloneTestRepo {
+    doLast {
+        def tempDir = new File("${project.buildDir}/tempTestRepo")
+        def testResourcesDir = new File("${project.projectDir}/tests/resources")
+        if (!testResourcesDir.exists()) {
+            testResourcesDir.mkdirs()
+        }
+        exec {
+            workingDir testResourcesDir.parentFile
+            commandLine 'git', 'clone', 'https://github.com/nipunayf/toml-test.git', testResourcesDir.name, '-b', 'resources'
+        }
+    }
+}
+
+task cleanupTestRepo {
+    doLast {
+        def testResourcesDir = new File("${project.projectDir}/tests/resources")
+        testResourcesDir.deleteDir()
+    }
+}
+
+test.finalizedBy cleanupTestRepo
+test.dependsOn cloneTestRepo
+
 updateTomlFiles.dependsOn copyStdlibs
 
 build.dependsOn "generatePomFileForMavenPublication"

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -104,29 +104,15 @@ publishing {
     }
 }
 
-task cloneTestRepo {
+task checkAndUpdateSubmodule {
     doLast {
-        def testResourcesDir = new File("${project.projectDir}/tests/resources")
-        if (!testResourcesDir.exists()) {
-            testResourcesDir.mkdirs()
-        }
-        exec {
-            workingDir testResourcesDir.parentFile
-            commandLine 'git', 'clone', 'https://github.com/nipunayf/toml-test.git', testResourcesDir.name, '-b', 'resources'
-        }
+        def initCommand = ['git', 'submodule', 'update', '--init', '--recursive']
+        initCommand.execute(null, projectDir).waitFor()
+        println "Submodule initialized successfully."
     }
 }
 
-task cleanupTestRepo {
-    doLast {
-        def testResourcesDir = new File("${project.projectDir}/tests/resources")
-        testResourcesDir.deleteDir()
-    }
-}
-
-test.finalizedBy cleanupTestRepo
-test.dependsOn cloneTestRepo
-
+test.dependsOn checkAndUpdateSubmodule
 updateTomlFiles.dependsOn copyStdlibs
 
 build.dependsOn "generatePomFileForMavenPublication"

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -106,7 +106,6 @@ publishing {
 
 task cloneTestRepo {
     doLast {
-        def tempDir = new File("${project.buildDir}/tempTestRepo")
         def testResourcesDir = new File("${project.projectDir}/tests/resources")
         if (!testResourcesDir.exists()) {
             testResourcesDir.mkdirs()

--- a/ballerina/tests/it.bal
+++ b/ballerina/tests/it.bal
@@ -16,7 +16,7 @@ import ballerina/test;
 
 @test:Config {
     dataProvider: validTomlDataGen,
-    enable: false
+    enable: true
 }
 function testValidTOML(string inputPath, json expectedOutput) returns error? {
     map<json> output = check readFile(inputPath, {parseOffsetDateTime: false});
@@ -25,7 +25,7 @@ function testValidTOML(string inputPath, json expectedOutput) returns error? {
 
 @test:Config {
     dataProvider: invalidTomlDataGen,
-    enable: false
+    enable: true
 }
 function testInvalidTOML(string inputPath) {
     map<json>|error output = readFile(inputPath);

--- a/ballerina/tests/it.bal
+++ b/ballerina/tests/it.bal
@@ -15,8 +15,7 @@
 import ballerina/test;
 
 @test:Config {
-    dataProvider: validTomlDataGen,
-    enable: true
+    dataProvider: validTomlDataGen
 }
 function testValidTOML(string inputPath, json expectedOutput) returns error? {
     map<json> output = check readFile(inputPath, {parseOffsetDateTime: false});
@@ -24,8 +23,7 @@ function testValidTOML(string inputPath, json expectedOutput) returns error? {
 }
 
 @test:Config {
-    dataProvider: invalidTomlDataGen,
-    enable: true
+    dataProvider: invalidTomlDataGen
 }
 function testInvalidTOML(string inputPath) {
     map<json>|error output = readFile(inputPath);


### PR DESCRIPTION
## Purpose

This PR aims to reintroduce community-driven test suites into the `ballerina/toml`. These test suites were previously managed as Git submodules and are critical for ensuring the robustness and reliability of the read APIs provided by these modules. 

Related to: https://github.com/ballerina-platform/ballerina-library/issues/6129

## Examples

N/A - This PR focuses on test suite integration rather than API usage examples.

## Checklist
- [x] Linked to an issue ([#6129](https://github.com/ballerina-platform/ballerina-library/issues/6129))
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec (if applicable)
- [ ] Checked native-image compatibility (if applicable)
