### PR TITLE
Add the integration test suite for the readString API

### DIFF
--- a/ballerina/modules/lexer/context.bal
+++ b/ballerina/modules/lexer/context.bal
@@ -19,7 +19,6 @@
 isolated function contextExpressionKey(LexerState state) returns LexerState|LexicalError {
     // Check for line breaks when reading a string
     if state.peek() == "\n" {
-        state.isNewLine = true;
         return state.tokenize(EOL);
     }
 
@@ -126,7 +125,6 @@ isolated function contextDateTime(LexerState state) returns LexerState|LexicalEr
             return state.tokenize(EOL);
         }
         "\n" => { // Check for line breaks when reading from string
-            state.isNewLine = true;
             return state.tokenize(EOL);
         }
         ":" => { // Check for time separator
@@ -169,7 +167,6 @@ isolated function contextExpressionValue(LexerState state) returns LexerState|Le
             return scan(state);
         }
         "\n" => { // Check for line breaks when reading from string
-            state.isNewLine = true;
             return state.tokenize(EOL);
         }
         "#" => { // Ignore comments

--- a/ballerina/modules/lexer/scan.bal
+++ b/ballerina/modules/lexer/scan.bal
@@ -236,7 +236,7 @@ isolated function scanDigit(isolated function (string:Char char) returns boolean
             return false;
         }
 
-        if checkCharacter(state, [" ", "#", "\t", "\n"]) {
+        if checkCharacter(state, [" ", "#", "\t"]) || state.isNewLine(state.peek()) {
             state.forward(-1);
             return true;
         }

--- a/ballerina/modules/lexer/state.bal
+++ b/ballerina/modules/lexer/state.bal
@@ -29,8 +29,6 @@ public class LexerState {
     # Output TOML token
     TOMLToken token = DUMMY;
 
-    public boolean isNewLine = false;
-
     public isolated function row() returns int => self.lineNumber + 1;
 
     public isolated function column() returns int => self.index + 1;
@@ -45,7 +43,6 @@ public class LexerState {
         self.index = 0;
         self.line = line;
         self.lineNumber = lineNumber;
-        self.isNewLine = false;
     }
 
     # Increment the index of the column by k indexes

--- a/ballerina/modules/lexer/state.bal
+++ b/ballerina/modules/lexer/state.bal
@@ -85,4 +85,11 @@ public class LexerState {
             value: lexemeBuffer
         };
     }
+
+    # Check if the current character is a new line. 
+    # This should be replaced by the os module once it supports an API: #4931.
+    # 
+    # + char - character to be checked
+    # + return - True if the current character is a new line
+    public isolated function isNewLine(string? char) returns boolean => char == "\n" || char == "\r\n";
 }

--- a/ballerina/modules/parser/parser.bal
+++ b/ballerina/modules/parser/parser.bal
@@ -26,7 +26,7 @@ public isolated function parse(string[] inputLines, boolean parseOffsetDateTime)
     ParserState state = new (inputLines, parseOffsetDateTime);
 
     // Iterating each line of the document
-    while state.lineIndex < state.numLines - 1 || state.lexerState.isNewLine {
+    while state.lineIndex < state.numLines - 1 {
         check state.initLexer(generateGrammarError(state, "Cannot open the TOML document"));
         check checkToken(state);
 

--- a/ballerina/modules/parser/state.bal
+++ b/ballerina/modules/parser/state.bal
@@ -77,15 +77,10 @@ class ParserState {
     # + return - An error if it fails to initialize  
     isolated function initLexer(GrammarError err) returns ParsingError? {
         self.lineIndex += 1;
-        string line;
-        if self.lexerState.isNewLine {
-            line = self.lexerState.line.substring(self.lexerState.index);
-        } else {
-            if self.lineIndex >= self.numLines {
-                return err;
-            }
-            line = self.lines[self.lineIndex];
+        if self.lineIndex >= self.numLines {
+            return err;
         }
+        string line = self.lines[self.lineIndex];
         self.lexerState.setLine(line, self.lineIndex);
     }
 

--- a/ballerina/tests/api_test.bal
+++ b/ballerina/tests/api_test.bal
@@ -17,8 +17,7 @@ import ballerina/io;
 import ballerina/test;
 
 @test:Config {
-    groups: ["api"],
-    enable: false
+    groups: ["api"]
 }
 function testReadTOMLString() returns error? {
     map<json> output = check readString(string

--- a/ballerina/tests/it.bal
+++ b/ballerina/tests/it.bal
@@ -13,19 +13,45 @@
 // limitations under the License.
 
 import ballerina/test;
+import ballerina/io;
 
 @test:Config {
     dataProvider: validTomlDataGen
 }
-function testValidTOML(string inputPath, json expectedOutput) returns error? {
+function testValidTomlForReadFile(string inputPath, json expectedOutput) returns error? {
     map<json> output = check readFile(inputPath, {parseOffsetDateTime: false});
+    test:assertEquals(output, expectedOutput);
+}
+
+@test:Config {
+    dataProvider: validTomlDataGen
+}
+function testValidTomlForReadString(string inputPath, json expectedOutput) returns error? {
+    map<json> output = check readString(check readStringFromFile(inputPath), {parseOffsetDateTime: false});
     test:assertEquals(output, expectedOutput);
 }
 
 @test:Config {
     dataProvider: invalidTomlDataGen
 }
-function testInvalidTOML(string inputPath) {
+function testInvalidTomlForReadFile(string inputPath) {
     map<json>|error output = readFile(inputPath);
     test:assertTrue(output is error);
+}
+
+@test:Config {
+    dataProvider: invalidTomlDataGen
+}
+function testInvalidTomlForReadString(string inputPath) returns error? {
+    string|error tomlContent = readStringFromFile(inputPath);
+    if tomlContent is string {
+        map<json>|error output = readString(tomlContent);
+        test:assertTrue(output is error);
+    }
+}
+
+function readStringFromFile(string filePath) returns string|error {
+    io:ReadableByteChannel byteChannel = check io:openReadableFile(filePath);
+    (byte[] & readonly) readBytes = check byteChannel.readAll();
+    return string:fromBytes(readBytes);
 }

--- a/ballerina/toml.bal
+++ b/ballerina/toml.bal
@@ -22,7 +22,9 @@ import toml.parser;
 # + config - Configuration for reading a TOML file
 # + return - TOML map object on success. Else, returns an error
 public isolated function readString(string tomlString, *ReadConfig config) returns map<json>|Error {
-    string[] lines = [tomlString];
+    io:ReadableByteChannel byteChannel = check io:createReadableChannel(tomlString.toBytes());
+    io:ReadableCharacterChannel charChannel = new (byteChannel, io:DEFAULT_ENCODING);
+    string[] lines = check charChannel.readAllLines();
     return check parser:parse(lines, config.parseOffsetDateTime);
 }
 


### PR DESCRIPTION
## Purpose
As a measure to increase the reliability of the readString API, the integration test suite has been used to ensure the robustness of this API. The PR addresses the following points:

1. The API implementations are refactored to follow a uniform path, making the code more readable.
2. The lexer is modified to support the newline character in Windows.

Fixes https://github.com/ballerina-platform/ballerina-library/issues/6153
Fixes https://github.com/ballerina-platform/ballerina-library/issues/4339
Fixes https://github.com/ballerina-platform/ballerina-library/issues/4338


## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
